### PR TITLE
Condivise voci in un modulo riutilizzabile

### DIFF
--- a/src/components/PodcastGenerator.tsx
+++ b/src/components/PodcastGenerator.tsx
@@ -15,22 +15,9 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
 import { parseTextWithTones } from "@/lib/parseTextWithTones";
 import { toneMap } from "@/lib/toneTypes";
-import type { VoiceName } from "@/components/VoiceSelector";
+import { voices, type VoiceName } from "@/lib/voices";
 import ThemeToggle from "@/components/ThemeToggle";
 
-const voices: VoiceName[] = [
-  "alloy",
-  "ash",
-  "ballad",
-  "coral",
-  "echo",
-  "fable",
-  "onyx",
-  "nova",
-  "sage",
-  "shimmer",
-  "verse",
-];
 
 const tones = Object.keys(toneMap) as (keyof typeof toneMap)[];
 

--- a/src/components/VoiceSelector.tsx
+++ b/src/components/VoiceSelector.tsx
@@ -1,22 +1,7 @@
 "use client";
 import React from 'react';
 // Drop‑down per la selezione della voce narrante
-
-const voices = [
-  "alloy",
-  "ash",
-  "ballad",
-  "coral",
-  "echo",
-  "fable",
-  "onyx",
-  "nova",
-  "sage",
-  "shimmer",
-  "verse",
-] as const;
-
-export type VoiceName = (typeof voices)[number];
+import { voices, type VoiceName } from "@/lib/voices";
 
 export default function VoiceSelector({
   value,

--- a/src/lib/voices.ts
+++ b/src/lib/voices.ts
@@ -1,0 +1,15 @@
+export const voices = [
+  "alloy",
+  "ash",
+  "ballad",
+  "coral",
+  "echo",
+  "fable",
+  "onyx",
+  "nova",
+  "sage",
+  "shimmer",
+  "verse",
+] as const;
+
+export type VoiceName = (typeof voices)[number];


### PR DESCRIPTION
## Summary
- centralize voice list and `VoiceName` type in `src/lib/voices.ts`
- import voices from the new module in `VoiceSelector` and `PodcastGenerator`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684826630ea88327a6f04a68a0aee1c3