### PR TITLE
Add progress indicator to PodcastGenerator

### DIFF
--- a/src/components/PodcastGenerator.tsx
+++ b/src/components/PodcastGenerator.tsx
@@ -40,6 +40,8 @@ export default function PodcastGenerator() {
   const [, setFile] = useState<File | null>(null);
   const [voice, setVoice] = useState<VoiceName | "">("");
   const [isGenerating, setIsGenerating] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [total, setTotal] = useState(0);
   const [downloadUrl, setDownloadUrl] = useState<string | null>(null);
   const [fragments, setFragments] = useState<{ url: string; label: string }[]>([]);
   const [apiKey, setApiKey] = useState<string>(
@@ -66,9 +68,11 @@ export default function PodcastGenerator() {
     setFragments([]);
 
     const sections = parseTextWithTones(text);
+    setProgress(0);
+    setTotal(sections.length);
     const base64Parts: string[] = [];
 
-    for (const s of sections) {
+    for (const [idx, s] of sections.entries()) {
       const res = await fetch("/api/generateFragment", {
         method: "POST",
         headers: {
@@ -93,6 +97,7 @@ export default function PodcastGenerator() {
       base64Parts.push(
         btoa(String.fromCharCode(...new Uint8Array(buf))),
       );
+      setProgress(idx + 1);
     }
 
     const joinRes = await fetch("/api/combineAudio", {
@@ -109,6 +114,7 @@ export default function PodcastGenerator() {
     const url = URL.createObjectURL(finalBlob);
     setDownloadUrl(url);
     setIsGenerating(false);
+    setProgress(sections.length);
   }
 
   function applyToneTag(tone: keyof typeof toneMap) {
@@ -225,6 +231,20 @@ export default function PodcastGenerator() {
             >
               {isGenerating ? "Generazione..." : "Genera Podcast"}
             </Button>
+
+            {isGenerating && total > 0 && (
+              <div className="space-y-1">
+                <div className="w-full h-2 rounded-full bg-white/20 overflow-hidden">
+                  <div
+                    className="h-full bg-pink-600 transition-all"
+                    style={{ width: `${(progress / total) * 100}%` }}
+                  />
+                </div>
+                <p className="text-xs text-center text-white/80">
+                  {progress}/{total}
+                </p>
+              </div>
+            )}
 
             {(fragments.length > 0 || downloadUrl) && (
               <div className="space-y-2">


### PR DESCRIPTION
## Summary
- show generation progress in PodcastGenerator

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848268327008327a8d42a1fb95227c9